### PR TITLE
Fix(createDatabase): Linux is case-sensitive

### DIFF
--- a/app/api/createDatabase/route.tsx
+++ b/app/api/createDatabase/route.tsx
@@ -30,16 +30,16 @@ export async function POST() {
         project_id INT PRIMARY KEY AUTO_INCREMENT,
         name VARCHAR(255) NOT NULL,
         owner INT NOT NULL,
-        FOREIGN KEY (owner) REFERENCES users(user_id)
+        FOREIGN KEY (owner) REFERENCES Users(user_id)
       );
     `);
 
     await connection.execute(`
       CREATE TABLE IF NOT EXISTS Editor (
         user_id INT NOT NULL,
-        FOREIGN KEY (user_id) REFERENCES users(user_id),
+        FOREIGN KEY (user_id) REFERENCES Users(user_id),
         project_id INT NOT NULL, 
-        FOREIGN KEY (project_id) REFERENCES projects(project_id)
+        FOREIGN KEY (project_id) REFERENCES Projects(project_id)
       );
     `);
 
@@ -47,7 +47,7 @@ export async function POST() {
       CREATE TABLE IF NOT EXISTS Object (
         object_id INT PRIMARY KEY AUTO_INCREMENT,
         author INT NOT NULL,
-        FOREIGN KEY (author) REFERENCES users(user_id)
+        FOREIGN KEY (author) REFERENCES Users(user_id)
       );
     `);
 
@@ -56,9 +56,9 @@ export async function POST() {
         folder_id INT PRIMARY KEY AUTO_INCREMENT,
         name VARCHAR(255) NOT NULL,
         project_id INT NOT NULL,
-        FOREIGN KEY (project_id) REFERENCES projects(project_id),
+        FOREIGN KEY (project_id) REFERENCES Projects(project_id),
         parent_folder_id INT,
-        FOREIGN KEY (parent_folder_id) REFERENCES folder(folder_id)
+        FOREIGN KEY (parent_folder_id) REFERENCES Folder(folder_id)
       );
     `);
 
@@ -67,7 +67,7 @@ export async function POST() {
         item_id INT PRIMARY KEY AUTO_INCREMENT,
         name VARCHAR(255) NOT NULL,
         folder_id INT NOT NULL,
-        FOREIGN KEY (folder_id) REFERENCES folder(folder_id)
+        FOREIGN KEY (folder_id) REFERENCES Folder(folder_id)
       );
     `);
 
@@ -75,7 +75,7 @@ export async function POST() {
       CREATE TABLE IF NOT EXISTS Version (
         version_id INT PRIMARY KEY AUTO_INCREMENT,
         item_id INT NOT NULL,
-        FOREIGN KEY (item_id) REFERENCES item(item_id),
+        FOREIGN KEY (item_id) REFERENCES Item(item_id),
         year INT NOT NULL,
         month INT NOT NULL,
         iteration INT NOT NULL
@@ -85,9 +85,9 @@ export async function POST() {
     await connection.execute(`
       CREATE TABLE IF NOT EXISTS Version_Object (
         version_id int NOT NULL,
-        FOREIGN KEY (version_id) REFERENCES version(version_id),
+        FOREIGN KEY (version_id) REFERENCES Version(version_id),
         object_id int NOT NULL,
-        FOREIGN KEY (object_id) REFERENCES object(object_id)
+        FOREIGN KEY (object_id) REFERENCES Object(object_id)
       );
     `);
     await connection.end();


### PR DESCRIPTION
Fix an issue in the createDatabase API. On Linux SQL statements are seemingly case-sensitive.